### PR TITLE
Polling intervall reduced to 1 sec when using RS232

### DIFF
--- a/Class3.cs
+++ b/Class3.cs
@@ -668,7 +668,7 @@ namespace VSCaptureMP
 
         public async Task SendCycledExtendedPollWaveDataRequest(int nInterval)
         {
-            int nmillisecond = nInterval * 1000;
+            int nmillisecond = nInterval ;
             if (nmillisecond != 0)
             {
                 do


### PR DESCRIPTION
Using VSC with the Phillips Intelliviue MX550 I noticed that after
10 min there is a Data leak for ~ 6 min. VSC used to send a polling
request for wave data every 16,6667min but the Phillips Intellivue
expects a new polling request earlier and times out sending wave data.
I tested this change for 17h with the Phillips Intelliviue demo mode and there
where no data leaks after the fix.